### PR TITLE
Fix invalid tree coordinates in Python output

### DIFF
--- a/faerun/faerun.py
+++ b/faerun/faerun.py
@@ -662,36 +662,36 @@ class Faerun(object):
                 output[name]["s"] = np.array(data[mapping["s"]], dtype=np.float32)
 
             output[name]["colors"] = [{}] * len(data[mapping["c"]])
-            for s in range(len(data[mapping["c"]])):
+            for series in range(len(data[mapping["c"]])):
                 if mapping["cs"] in data:
-                    colors = np.array([cmaps[s](x) for x in data[mapping["c"]][s]])
+                    colors = np.array([cmaps[series](x) for x in data[mapping["c"]][series]])
 
                     for i, c in enumerate(colors):
                         hsl = np.array(colour.rgb2hsl(c[:3]))
-                        hsl[1] = hsl[1] - hsl[1] * data[mapping["cs"]][s][i]
+                        hsl[1] = hsl[1] - hsl[1] * data[mapping["cs"]][series][i]
                         colors[i] = np.append(np.array(colour.hsl2rgb(hsl)), 1.0)
 
                     colors = np.round(colors * 255.0)
 
-                    output[name]["colors"][s]["r"] = np.array(
+                    output[name]["colors"][series]["r"] = np.array(
                         colors[:, 0], dtype=np.float32
                     )
-                    output[name]["colors"][s]["g"] = np.array(
+                    output[name]["colors"][series]["g"] = np.array(
                         colors[:, 1], dtype=np.float32
                     )
-                    output[name]["colors"][s]["b"] = np.array(
+                    output[name]["colors"][series]["b"] = np.array(
                         colors[:, 2], dtype=np.float32
                     )
                 else:
-                    colors = np.array([cmaps[s](x) for x in data[mapping["c"]][s]])
+                    colors = np.array([cmaps[series](x) for x in data[mapping["c"]][series]])
                     colors = np.round(colors * 255.0)
-                    output[name]["colors"][s]["r"] = np.array(
+                    output[name]["colors"][series]["r"] = np.array(
                         colors[:, 0], dtype=np.float32
                     )
-                    output[name]["colors"][s]["g"] = np.array(
+                    output[name]["colors"][series]["g"] = np.array(
                         colors[:, 1], dtype=np.float32
                     )
-                    output[name]["colors"][s]["b"] = np.array(
+                    output[name]["colors"][series]["b"] = np.array(
                         colors[:, 2], dtype=np.float32
                     )
 

--- a/faerun/faerun.py
+++ b/faerun/faerun.py
@@ -543,12 +543,12 @@ class Faerun(object):
         if Faerun.in_notebook():
             model["data"] = self.create_data()
         else:
-            with open(js_path, "w") as f:
+            with open(js_path, "w", encoding="utf-8") as f:
                 f.write(self.create_data())
 
         output_text = jenv.get_template(template).render(model)
 
-        with open(html_path, "w") as result_file:
+        with open(html_path, "w", encoding="utf-8") as result_file:
             result_file.write(output_text)
 
         if Faerun.in_notebook():

--- a/faerun/faerun.py
+++ b/faerun/faerun.py
@@ -168,7 +168,6 @@ class Faerun(object):
             },
             "color-box": {"width": "15px", "height": "15px", "border": "solid 0px"},
             "color-stripe": {"width": "15px", "height": "1px", "border": "solid 0px"},
-            "color-stripe": {"width": "15px", "height": "1px", "border": "solid 0px"},
             "crosshair": {"background-color": "#fff"},
         }
 

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open("README.md", "r") as fh:
     LONG_DESCRIPTION = fh.read()
 
 NAME = "faerun"
-VERSION = "0.4.2"
+VERSION = "0.4.3"
 AUTHOR = "Daniel Probst"
 DESCRIPTION = "A python package for generating interactive views of chemical spaces."
 URL = "https://github.com/reymond-group/faerun-python"


### PR DESCRIPTION
This PR addresses #10 by fixing `create_python_data()` variable issue and adding "utf-8" as a default HTML and JS output encoding. Details:
- Duplicate style removed
- "utf-8" set as default encoding for output HTML and JS files - this allows using unicode characters in labels for WIndows
- variable "s" renamed to "series" for loop in `create_python_data()` method similar to `create_data()` method to avoid overlap with scale variable in the same method
- version bump